### PR TITLE
Increase Xdebug Nesting Level

### DIFF
--- a/files/xdebug.ini
+++ b/files/xdebug.ini
@@ -124,7 +124,7 @@ xdebug.manual_url=http://www.php.net
 ; Controls the protection mechanism for infinite recursion protection. The value
 ; of this setting is the maximum level of nested functions that are allowed before
 ; the script will be aborted.
-xdebug.max_nesting_level=100
+xdebug.max_nesting_level=250
 
 ; Introduced in Xdebug 2.1
 ; By default Xdebug overloads var_dump() with its own improved version for displaying


### PR DESCRIPTION
When Magento2 first tries to build caches and tags after installation, the event observers can cause Xdebug to choke on the number of recursive functions.

An issue was raised with Magento about this (in a different context) in https://github.com/magento/magento2/issues/427
