### PR TITLE
Updated composer handling in reinstall

### DIFF
--- a/files/reinstall.sh
+++ b/files/reinstall.sh
@@ -27,9 +27,6 @@ done
 cd /vagrant/data/magento2
 rm -rf var/*
 composer install
-cd setup
-rm composer.lock
-composer install
 export MAGE_MODE='developer'
 echo "Uninstalling..."
 php -f index.php -- uninstall


### PR DESCRIPTION
`composer.lock` is now versioned by Magento so I believe it shouldn't be deleted.

Also, there is no `setup/composer.json` anymore so I removed the code related to this.

Feel free to edit the commits as needed.
