### PR TITLE
Fix Mounting NFS shared folders.

### DIFF
--- a/manifests/mage.pp
+++ b/manifests/mage.pp
@@ -34,6 +34,7 @@ package {[
     'python',
     'graphviz',
     'mysqltuner',
+    'nfs-common',
     ]:
     ensure  => 'latest',
     require => Exec['apt-get update']


### PR DESCRIPTION
i got this error at the first try

```
The following SSH command responded with a non-zero exit status.
Vagrant assumes that this means the command failed!

mount -o 'vers=3,udp' 192.168.56.1:'/var/www/test' /vagrant

Stdout from the command:



Stderr from the command:

stdin: is not a tty
mount: wrong fs type, bad option, bad superblock on 192.168.56.1:/var/www/test,
       missing codepage or helper program, or other error
       (for several filesystems (e.g. nfs, cifs) you might
       need a /sbin/mount.<type> helper program)
       In some cases useful info is found in syslog - try
       dmesg | tail  or so
```