### PR TITLE
Removes stdin is not a tty

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,6 +14,9 @@ Vagrant.configure("2") do |config|
   config.vm.hostname = "mage2.dev"
   config.ssh.forward_agent = "true"
 
+  # Removes stdin: is not a tty
+  config.ssh.shell = "bash -c 'BASH_ENV=/etc/profile exec bash'"
+  
   # Create a private network, which allows host-only access to the machine
   # using a specific IP.
   config.vm.network :private_network, ip: "192.168.56.10"

--- a/files/bash_aliases
+++ b/files/bash_aliases
@@ -1,2 +1,3 @@
 alias m="cd /vagrant/data/magento2"
 alias mt="m && php dev/tools/tests.php -- type::all"
+alias ll="ls -l"

--- a/files/bash_aliases
+++ b/files/bash_aliases
@@ -1,3 +1,3 @@
 alias m="cd /vagrant/data/magento2"
 alias mt="m && php dev/tools/tests.php -- type::all"
-alias ll="ls -l"
+alias ll="ls -la"


### PR DESCRIPTION
Not sure thought why we get this warning that /etc/puppet/hiera.yaml does not exists. any ideas?

![8](https://cloud.githubusercontent.com/assets/16985712/26657362/a891257c-4663-11e7-93e0-e450d3ae1a88.jpg)
